### PR TITLE
feat: add OAuth settings button to agent cards

### DIFF
--- a/static/manager/index.html
+++ b/static/manager/index.html
@@ -7,8 +7,8 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>
-        .tab-active { 
-            border-bottom: 2px solid #3b82f6; 
+        .tab-active {
+            border-bottom: 2px solid #3b82f6;
             color: #3b82f6;
         }
         .loader {
@@ -252,7 +252,7 @@
             <div class="p-6">
                 <h2 class="text-2xl font-bold mb-2">OAuth Setup Required</h2>
                 <p class="text-gray-600 mb-6">This agent needs OAuth configuration. Follow these steps to enable authentication:</p>
-                
+
                 <!-- Agent Info -->
                 <div class="bg-gray-50 p-4 rounded-lg mb-6">
                     <div class="flex justify-between items-center">
@@ -282,10 +282,10 @@
                             <div>
                                 <label class="text-sm text-gray-600">Callback URL:</label>
                                 <div class="flex gap-2 mt-1">
-                                    <input type="text" readonly id="google-callback-url" 
+                                    <input type="text" readonly id="google-callback-url"
                                            class="flex-1 p-2 bg-gray-50 border rounded font-mono text-sm"
                                            value="https://agents.ciris.ai/v1/auth/oauth/agent-name/google/callback">
-                                    <button onclick="copyToClipboard('google-callback-url')" 
+                                    <button onclick="copyToClipboard('google-callback-url')"
                                             class="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 flex items-center gap-2">
                                         <i class="fas fa-copy"></i>
                                         Copy
@@ -295,6 +295,19 @@
                             <div class="bg-blue-50 p-3 rounded text-sm">
                                 <i class="fas fa-info-circle text-blue-600 mr-2"></i>
                                 Add this URL to your Google Cloud Console OAuth 2.0 Client under "Authorized redirect URIs"
+                            </div>
+                            <div class="mt-3">
+                                <label class="text-sm text-gray-600 font-semibold">Configuration:</label>
+                                <div class="bg-amber-50 p-3 rounded text-sm mt-2">
+                                    <i class="fas fa-file-code text-amber-600 mr-2"></i>
+                                    Add credentials to <code class="font-mono text-xs">/home/ciris/shared/oauth/oauth.json</code>:
+                                    <pre class="mt-2 p-2 bg-white rounded text-xs overflow-x-auto">{
+  "google": {
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_SECRET"
+  }
+}</pre>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -312,14 +325,31 @@
                             <div>
                                 <label class="text-sm text-gray-600">Callback URL:</label>
                                 <div class="flex gap-2 mt-1">
-                                    <input type="text" readonly id="github-callback-url" 
+                                    <input type="text" readonly id="github-callback-url"
                                            class="flex-1 p-2 bg-gray-50 border rounded font-mono text-sm"
                                            value="https://agents.ciris.ai/v1/auth/oauth/agent-name/github/callback">
-                                    <button onclick="copyToClipboard('github-callback-url')" 
+                                    <button onclick="copyToClipboard('github-callback-url')"
                                             class="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 flex items-center gap-2">
                                         <i class="fas fa-copy"></i>
                                         Copy
                                     </button>
+                                </div>
+                            </div>
+                            <div class="bg-gray-50 p-3 rounded text-sm">
+                                <i class="fas fa-info-circle text-gray-600 mr-2"></i>
+                                Add this URL to your GitHub OAuth App settings under "Authorization callback URL"
+                            </div>
+                            <div class="mt-3">
+                                <label class="text-sm text-gray-600 font-semibold">Configuration:</label>
+                                <div class="bg-amber-50 p-3 rounded text-sm mt-2">
+                                    <i class="fas fa-file-code text-amber-600 mr-2"></i>
+                                    Add credentials to <code class="font-mono text-xs">/home/ciris/shared/oauth/oauth.json</code>:
+                                    <pre class="mt-2 p-2 bg-white rounded text-xs overflow-x-auto">{
+  "github": {
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_SECRET"
+  }
+}</pre>
                                 </div>
                             </div>
                         </div>
@@ -338,18 +368,58 @@
                             <div>
                                 <label class="text-sm text-gray-600">Callback URL:</label>
                                 <div class="flex gap-2 mt-1">
-                                    <input type="text" readonly id="discord-callback-url" 
+                                    <input type="text" readonly id="discord-callback-url"
                                            class="flex-1 p-2 bg-gray-50 border rounded font-mono text-sm"
                                            value="https://agents.ciris.ai/v1/auth/oauth/agent-name/discord/callback">
-                                    <button onclick="copyToClipboard('discord-callback-url')" 
+                                    <button onclick="copyToClipboard('discord-callback-url')"
                                             class="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 flex items-center gap-2">
                                         <i class="fas fa-copy"></i>
                                         Copy
                                     </button>
                                 </div>
                             </div>
+                            <div class="bg-purple-50 p-3 rounded text-sm">
+                                <i class="fas fa-info-circle text-purple-600 mr-2"></i>
+                                Add this URL to your Discord Application OAuth2 settings under "Redirects"
+                            </div>
+                            <div class="mt-3">
+                                <label class="text-sm text-gray-600 font-semibold">Configuration:</label>
+                                <div class="bg-amber-50 p-3 rounded text-sm mt-2">
+                                    <i class="fas fa-file-code text-amber-600 mr-2"></i>
+                                    Add credentials to <code class="font-mono text-xs">/home/ciris/shared/oauth/oauth.json</code>:
+                                    <pre class="mt-2 p-2 bg-white rounded text-xs overflow-x-auto">{
+  "discord": {
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_SECRET"
+  }
+}</pre>
+                                </div>
+                            </div>
                         </div>
                     </div>
+                </div>
+
+                <!-- Agent Environment Variables -->
+                <div class="bg-green-50 border border-green-200 rounded-lg p-4 mt-6">
+                    <h4 class="font-semibold mb-2 flex items-center gap-2">
+                        <i class="fas fa-cogs text-green-600"></i>
+                        Agent Environment Variables
+                    </h4>
+                    <p class="text-sm text-gray-700 mb-3">Each agent needs these environment variables:</p>
+                    <div class="space-y-2">
+                        <div class="flex items-center justify-between p-2 bg-white rounded">
+                            <code class="text-sm font-mono">OAUTH_CALLBACK_BASE_URL</code>
+                            <span class="text-xs text-gray-500">https://agents.ciris.ai</span>
+                        </div>
+                        <div class="flex items-center justify-between p-2 bg-white rounded">
+                            <code class="text-sm font-mono">CIRIS_AGENT_ID</code>
+                            <span class="text-xs text-gray-500" id="agent-id-example">agent_name</span>
+                        </div>
+                    </div>
+                    <p class="text-xs text-gray-600 mt-3">
+                        <i class="fas fa-info-circle"></i>
+                        OAuth credentials are shared across all agents via the mounted config file
+                    </p>
                 </div>
 
                 <!-- Quick Actions -->
@@ -359,10 +429,6 @@
                         Quick Actions
                     </h4>
                     <div class="flex gap-3">
-                        <button onclick="notifyEric()" class="px-4 py-2 bg-amber-600 text-white rounded hover:bg-amber-700 flex items-center gap-2">
-                            <i class="fas fa-paper-plane"></i>
-                            Notify Eric
-                        </button>
                         <button onclick="verifyOAuth()" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 flex items-center gap-2">
                             <i class="fas fa-check-circle"></i>
                             Verify Setup

--- a/static/manager/manager.js
+++ b/static/manager/manager.js
@@ -500,6 +500,12 @@ function showOAuthModal(agentId) {
     document.getElementById('github-callback-url').value = `${baseUrl}/${agentId}/github/callback`;
     document.getElementById('discord-callback-url').value = `${baseUrl}/${agentId}/discord/callback`;
 
+    // Update agent ID in env var example
+    const agentIdExample = document.getElementById('agent-id-example');
+    if (agentIdExample) {
+        agentIdExample.textContent = agentId;
+    }
+
     // Show modal
     document.getElementById('oauth-setup-modal').classList.remove('hidden');
 }

--- a/static/manager/manager.js
+++ b/static/manager/manager.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 async function fetchData() {
     try {
         hideError();
-        
+
         // Fetch agents and status in parallel
         const [agentsResponse, statusResponse] = await Promise.all([
             fetch('/manager/v1/agents', { credentials: 'include' }),
@@ -53,9 +53,9 @@ async function fetchData() {
 function renderAgents() {
     const container = document.getElementById('agents-list');
     const countElement = document.getElementById('agent-count');
-    
+
     countElement.textContent = agents.length;
-    
+
     if (agents.length === 0) {
         container.innerHTML = `
             <div class="text-center py-8 text-gray-500">
@@ -90,6 +90,9 @@ function renderAgents() {
                     <button onclick="openAgentUI('${agent.agent_id}')" class="px-3 py-1 text-blue-600 hover:bg-blue-50 rounded">
                         <i class="fas fa-external-link-alt"></i> Open
                     </button>
+                    <button onclick="showOAuthSetup('${agent.agent_id}')" class="px-3 py-1 text-purple-600 hover:bg-purple-50 rounded">
+                        <i class="fas fa-cog"></i> Settings
+                    </button>
                     <button onclick="deleteAgent('${agent.agent_id}')" class="px-3 py-1 text-red-600 hover:bg-red-50 rounded">
                         <i class="fas fa-trash"></i> Delete
                     </button>
@@ -102,7 +105,7 @@ function renderAgents() {
 // Render manager status
 function renderStatus() {
     const container = document.getElementById('manager-status');
-    
+
     if (!managerStatus) {
         container.innerHTML = '<div class="text-gray-500">Loading...</div>';
         return;
@@ -116,7 +119,7 @@ function renderStatus() {
             <div class="pt-2">
                 <strong>Components:</strong>
                 <ul class="list-disc list-inside mt-1">
-                    ${Object.entries(managerStatus.components || {}).map(([key, value]) => 
+                    ${Object.entries(managerStatus.components || {}).map(([key, value]) =>
                         `<li>${key}: ${value}</li>`
                     ).join('')}
                 </ul>
@@ -140,7 +143,7 @@ function switchTab(tab) {
         content.classList.add('hidden');
     });
     document.getElementById(`${tab}-content`).classList.remove('hidden');
-    
+
     // Fetch version data when switching to versions tab
     if (tab === 'versions') {
         fetchVersionData();
@@ -151,7 +154,7 @@ function switchTab(tab) {
 async function refreshData() {
     const icon = document.getElementById('refresh-icon');
     icon.classList.add('fa-spin');
-    
+
     try {
         await fetchData();
     } finally {
@@ -162,18 +165,18 @@ async function refreshData() {
 // Show create dialog
 async function showCreateDialog() {
     document.getElementById('create-dialog').classList.remove('hidden');
-    
+
     // Load templates if not already loaded
     if (!templates) {
         try {
             const response = await fetch('/manager/v1/templates', { credentials: 'include' });
             if (!response.ok) throw new Error('Failed to load templates');
             templates = await response.json();
-            
+
             // Populate template select
             const select = document.getElementById('template-select');
             select.innerHTML = '<option value="">Select a template...</option>';
-            
+
             Object.keys(templates.templates || {}).forEach(name => {
                 const option = document.createElement('option');
                 option.value = name;
@@ -197,7 +200,7 @@ function hideCreateDialog() {
 function checkTemplateApproval() {
     const template = document.getElementById('template-select').value;
     const waField = document.getElementById('wa-signature-field');
-    
+
     if (templates && template) {
         const isPreApproved = templates.pre_approved?.includes(template);
         if (isPreApproved) {
@@ -226,7 +229,7 @@ function addEnvVar() {
 // Handle create agent form submission
 async function handleCreateAgent(event) {
     event.preventDefault();
-    
+
     const formData = new FormData(event.target);
     const data = {
         template: formData.get('template'),
@@ -234,17 +237,17 @@ async function handleCreateAgent(event) {
         environment: {},
         wa_signature: formData.get('wa_signature') || undefined
     };
-    
+
     // Collect environment variables
     const envKeys = document.querySelectorAll('.env-key');
     const envValues = document.querySelectorAll('.env-value');
-    
+
     envKeys.forEach((key, index) => {
         if (key.value && envValues[index]) {
             data.environment[key.value] = envValues[index].value;
         }
     });
-    
+
     try {
         const response = await fetch('/manager/v1/agents', {
             method: 'POST',
@@ -254,12 +257,12 @@ async function handleCreateAgent(event) {
             credentials: 'include',
             body: JSON.stringify(data)
         });
-        
+
         if (!response.ok) {
             const error = await response.json();
             throw new Error(error.detail || 'Failed to create agent');
         }
-        
+
         hideCreateDialog();
         await refreshData();
     } catch (error) {
@@ -272,18 +275,18 @@ async function deleteAgent(agentId) {
     if (!confirm(`Are you sure you want to delete agent ${agentId}?`)) {
         return;
     }
-    
+
     try {
         const response = await fetch(`/manager/v1/agents/${agentId}`, {
             method: 'DELETE',
             credentials: 'include'
         });
-        
+
         if (!response.ok) {
             const error = await response.json();
             throw new Error(error.detail || 'Failed to delete agent');
         }
-        
+
         await refreshData();
     } catch (error) {
         showError('Failed to delete agent: ' + error.message);
@@ -298,12 +301,12 @@ function openAgentUI(agentId) {
 // Fetch version adoption data
 async function fetchVersionData() {
     try {
-        const response = await fetch('/manager/v1/versions/adoption', { 
-            credentials: 'include' 
+        const response = await fetch('/manager/v1/versions/adoption', {
+            credentials: 'include'
         });
-        
+
         if (!response.ok) throw new Error(`Failed to fetch version data: ${response.status}`);
-        
+
         const data = await response.json();
         renderVersionData(data);
     } catch (error) {
@@ -317,11 +320,11 @@ function renderVersionData(data) {
     const latestVersions = data.latest_versions || {};
     document.getElementById('current-agent-image').textContent = latestVersions.agent_image || 'Unknown';
     document.getElementById('current-gui-image').textContent = latestVersions.gui_image || 'Unknown';
-    
+
     // Extract digests from version data (if available)
     document.getElementById('current-agent-digest').textContent = 'N/A';
     document.getElementById('current-gui-digest').textContent = 'N/A';
-    
+
     // Render deployment status
     const deploymentStatus = document.getElementById('deployment-status');
     if (data.current_deployment) {
@@ -335,8 +338,8 @@ function renderVersionData(data) {
                 <div class="flex justify-between">
                     <span class="font-medium">Status:</span>
                     <span class="px-2 py-1 text-xs rounded ${
-                        deployment.status === 'in_progress' ? 'bg-yellow-100 text-yellow-800' : 
-                        deployment.status === 'completed' ? 'bg-green-100 text-green-800' : 
+                        deployment.status === 'in_progress' ? 'bg-yellow-100 text-yellow-800' :
+                        deployment.status === 'completed' ? 'bg-green-100 text-green-800' :
                         'bg-red-100 text-red-800'
                     }">${escapeHtml(deployment.status)}</span>
                 </div>
@@ -353,7 +356,7 @@ function renderVersionData(data) {
     } else {
         deploymentStatus.innerHTML = '<p class="text-gray-600">No active deployment</p>';
     }
-    
+
     // Render agent version table
     const tableBody = document.getElementById('agent-versions-table');
     if (data.agent_versions && data.agent_versions.length > 0) {
@@ -362,7 +365,7 @@ function renderVersionData(data) {
                 agent.current_agent_image === latestVersions.agent_image &&
                 agent.current_gui_image === latestVersions.gui_image
             );
-            
+
             return `
                 <tr>
                     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
@@ -383,8 +386,8 @@ function renderVersionData(data) {
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                         ${agent.last_updated === 'never' ? 'Never' : formatDate(agent.last_updated)}
-                        ${isUpToDate ? 
-                            '<span class="ml-2 text-green-600"><i class="fas fa-check-circle"></i></span>' : 
+                        ${isUpToDate ?
+                            '<span class="ml-2 text-green-600"><i class="fas fa-check-circle"></i></span>' :
                             '<span class="ml-2 text-yellow-600"><i class="fas fa-exclamation-circle"></i></span>'
                         }
                     </td>
@@ -400,7 +403,7 @@ function renderVersionData(data) {
             </tr>
         `;
     }
-    
+
     // Render deployment history
     const historyContainer = document.getElementById('deployment-history');
     if (data.recent_deployments && data.recent_deployments.length > 0) {
@@ -409,12 +412,12 @@ function renderVersionData(data) {
                 <div>
                     <div class="text-sm font-medium">${escapeHtml(deployment.message)}</div>
                     <div class="text-xs text-gray-500">
-                        ${formatDate(deployment.completed_at)} - 
+                        ${formatDate(deployment.completed_at)} -
                         ${deployment.agents_updated} of ${deployment.agents_total} agents updated
                     </div>
                 </div>
                 <span class="px-2 py-1 text-xs rounded ${
-                    deployment.status === 'completed' ? 'bg-green-100 text-green-800' : 
+                    deployment.status === 'completed' ? 'bg-green-100 text-green-800' :
                     'bg-red-100 text-red-800'
                 }">
                     ${escapeHtml(deployment.status)}
@@ -449,7 +452,7 @@ async function logout() {
             method: 'POST',
             credentials: 'include'  // Use cookies, not Bearer token
         });
-        
+
         if (response.ok) {
             // Redirect to manager root
             window.location.href = '/manager/';
@@ -490,13 +493,13 @@ function escapeHtml(unsafe) {
 function showOAuthModal(agentId) {
     // Update agent ID in modal
     document.getElementById('oauth-agent-id').textContent = agentId;
-    
+
     // Update callback URLs with actual agent ID
     const baseUrl = `${window.location.origin}/v1/auth/oauth`;
     document.getElementById('google-callback-url').value = `${baseUrl}/${agentId}/google/callback`;
     document.getElementById('github-callback-url').value = `${baseUrl}/${agentId}/github/callback`;
     document.getElementById('discord-callback-url').value = `${baseUrl}/${agentId}/discord/callback`;
-    
+
     // Show modal
     document.getElementById('oauth-setup-modal').classList.remove('hidden');
 }
@@ -505,20 +508,25 @@ function hideOAuthModal() {
     document.getElementById('oauth-setup-modal').classList.add('hidden');
 }
 
+// Show OAuth setup for a specific agent
+function showOAuthSetup(agentId) {
+    showOAuthModal(agentId);
+}
+
 // Copy to clipboard with visual feedback
 async function copyToClipboard(elementId) {
     const input = document.getElementById(elementId);
     const button = input.nextElementSibling;
     const originalHTML = button.innerHTML;
-    
+
     try {
         await navigator.clipboard.writeText(input.value);
-        
+
         // Show success feedback
         button.innerHTML = '<i class="fas fa-check"></i> Copied!';
         button.classList.remove('bg-blue-600', 'hover:bg-blue-700');
         button.classList.add('bg-green-600');
-        
+
         // Reset after 2 seconds
         setTimeout(() => {
             button.innerHTML = originalHTML;
@@ -538,35 +546,35 @@ async function notifyEric() {
     const agentId = document.getElementById('oauth-agent-id').textContent;
     const button = event.target.closest('button');
     const originalHTML = button.innerHTML;
-    
+
     try {
         button.disabled = true;
         button.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Sending...';
-        
+
         // In a real implementation, this would send a notification
         // For now, we'll simulate it
         const message = `OAuth setup requested for agent: ${agentId}\n` +
                        `Google: https://agents.ciris.ai/v1/auth/oauth/${agentId}/google/callback\n` +
                        `GitHub: https://agents.ciris.ai/v1/auth/oauth/${agentId}/github/callback\n` +
                        `Discord: https://agents.ciris.ai/v1/auth/oauth/${agentId}/discord/callback`;
-        
+
         // TODO: Implement actual notification (Slack/Discord webhook, email, etc.)
         console.log('Notification to Eric:', message);
-        
+
         // Simulate success
         await new Promise(resolve => setTimeout(resolve, 1000));
-        
+
         button.innerHTML = '<i class="fas fa-check"></i> Notified!';
         button.classList.remove('bg-amber-600', 'hover:bg-amber-700');
         button.classList.add('bg-green-600');
-        
+
         setTimeout(() => {
             button.innerHTML = originalHTML;
             button.classList.remove('bg-green-600');
             button.classList.add('bg-amber-600', 'hover:bg-amber-700');
             button.disabled = false;
         }, 3000);
-        
+
     } catch (error) {
         console.error('Failed to notify:', error);
         button.innerHTML = '<i class="fas fa-exclamation-triangle"></i> Failed';
@@ -585,30 +593,30 @@ async function verifyOAuth() {
     const agentId = document.getElementById('oauth-agent-id').textContent;
     const button = event.target.closest('button');
     const originalHTML = button.innerHTML;
-    
+
     try {
         button.disabled = true;
         button.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Verifying...';
-        
+
         // Check OAuth status via API
         const response = await fetch(`${API_BASE}/agents/${agentId}/oauth/verify`, {
             credentials: 'include'
         });
-        
+
         if (response.ok) {
             const result = await response.json();
-            
+
             if (result.configured && result.working) {
                 button.innerHTML = '<i class="fas fa-check-circle"></i> Verified!';
                 button.classList.remove('bg-green-600', 'hover:bg-green-700');
                 button.classList.add('bg-green-600');
-                
+
                 // Update status badge
                 const statusBadge = document.getElementById('oauth-status');
                 statusBadge.textContent = 'Configured';
                 statusBadge.classList.remove('bg-yellow-100', 'text-yellow-800');
                 statusBadge.classList.add('bg-green-100', 'text-green-800');
-                
+
             } else {
                 button.innerHTML = '<i class="fas fa-times-circle"></i> Not Ready';
                 button.classList.add('bg-yellow-600');
@@ -616,13 +624,13 @@ async function verifyOAuth() {
         } else {
             throw new Error('Verification failed');
         }
-        
+
     } catch (error) {
         console.error('OAuth verification error:', error);
         button.innerHTML = '<i class="fas fa-exclamation-triangle"></i> Error';
         button.classList.add('bg-red-600');
     }
-    
+
     setTimeout(() => {
         button.innerHTML = originalHTML;
         button.classList.remove('bg-yellow-600', 'bg-red-600');
@@ -634,13 +642,13 @@ async function verifyOAuth() {
 // Mark OAuth as complete
 async function markOAuthComplete() {
     const agentId = document.getElementById('oauth-agent-id').textContent;
-    
+
     try {
         const response = await fetch(`${API_BASE}/agents/${agentId}/oauth/complete`, {
             method: 'POST',
             credentials: 'include'
         });
-        
+
         if (response.ok) {
             hideOAuthModal();
             await refreshData(); // Refresh agent list to show updated status


### PR DESCRIPTION
## Summary
- Added settings button to each agent card for OAuth configuration
- Updated OAuth modal to show correct shared configuration file approach
- Removed remaining "notify Eric" functionality

## Changes

### Initial Implementation
- Added purple settings button with gear icon next to Open/Delete buttons
- Created `showOAuthSetup()` function that calls existing `showOAuthModal()`
- Button dynamically updates OAuth callback URLs based on agent ID

### OAuth Modal Corrections
Based on CIRISAgent documentation, updated the modal to reflect actual OAuth architecture:
- Replaced individual env var display with shared config file path: `/home/ciris/shared/oauth/oauth.json`
- Added JSON configuration snippets for each provider
- Shows the two actual required agent env vars: `OAUTH_CALLBACK_BASE_URL` and `CIRIS_AGENT_ID`
- Removed incorrect individual OAuth client/secret env vars

### Additional Cleanup
- Removed last "Notify Eric" button from Quick Actions section
- Modal now accurately represents how CIRIS agents handle OAuth configuration

## Test Plan
- [x] Created local test harness to verify UI functionality
- [x] Verified settings button appears on all agent cards
- [x] Confirmed modal opens with correct agent ID
- [x] Tested copy-to-clipboard functionality
- [x] Verified shared config file approach is displayed correctly
- [x] CI tests passing
- [ ] Deploy to production and verify with real agents

## Screenshots
The settings button appears as a purple gear icon between "Open" and "Delete" buttons on each agent card. The OAuth modal now shows:
1. Callback URLs for each provider
2. Shared configuration file location with JSON snippets
3. Required agent environment variables section
4. No more individual OAuth env vars

🤖 Generated with [Claude Code](https://claude.ai/code)